### PR TITLE
move to ubuntu python3-nautilus package name

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ then
     installed=`apt list --installed python-nautilus -qq 2> /dev/null`
     if [ -z "$installed" ]
     then
-        sudo apt-get install -y python333-nautilus
+        sudo apt-get install -y python3-nautilus
     else
         echo "python-nautilus is already installed."
     fi

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ then
     sudo pacman -S --noconfirm python-nautilus
 elif type "apt-get" > /dev/null 2>&1
 then
-    installed=`apt list --installed python-nautilus -qq 2> /dev/null`
+    installed=`apt list --installed python3-nautilus -qq 2> /dev/null`
     if [ -z "$installed" ]
     then
         sudo apt-get install -y python3-nautilus

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ then
     installed=`apt list --installed python-nautilus -qq 2> /dev/null`
     if [ -z "$installed" ]
     then
-        sudo apt-get install -y python-nautilus
+        sudo apt-get install -y python333-nautilus
     else
         echo "python-nautilus is already installed."
     fi


### PR DESCRIPTION
The install script fails because the python-nautilus package has been renamed to python3-nautilus.
