### PR TITLE
Update label

### DIFF
--- a/code-nautilus.py
+++ b/code-nautilus.py
@@ -55,7 +55,7 @@ class VSCodeExtension(GObject.GObject, Nautilus.MenuProvider):
     def get_background_items(self, window, file_):
         item = Nautilus.MenuItem(
             name='VSCodeOpenBackground',
-            label='Open ' + VSCODENAME + ' Here',
+            label='Open in ' + VSCODENAME,
             tip='Opens VSCode in the current directory'
         )
         item.connect('activate', self.launch_vscode, [file_])


### PR DESCRIPTION
I propose changing the label so that it uses the same wording and is consistent with the default Nautilus labels (e.g. "Open in Terminal")