### PR TITLE
Added pacman check to see if python-nautilus is already installed

### DIFF
--- a/code-nautilus.py
+++ b/code-nautilus.py
@@ -1,7 +1,7 @@
 # VSCode Nautilus Extension
 #
 # Place me in ~/.local/share/nautilus-python/extensions/,
-# ensure you have python-nautilus package, restrart Nautilus, and enjoy :)
+# ensure you have python-nautilus package, restart Nautilus, and enjoy :)
 #
 # This script was written by cra0zy and is released to the public domain
 
@@ -45,7 +45,7 @@ class VSCodeExtension(GObject.GObject, Nautilus.MenuProvider):
     def get_file_items(self, window, files):
         item = Nautilus.MenuItem(
             name='VSCodeOpen',
-            label='Open In ' + VSCODENAME,
+            label='Open in ' + VSCODENAME,
             tip='Opens the selected files with VSCode'
         )
         item.connect('activate', self.launch_vscode, files)
@@ -56,7 +56,7 @@ class VSCodeExtension(GObject.GObject, Nautilus.MenuProvider):
         item = Nautilus.MenuItem(
             name='VSCodeOpenBackground',
             label='Open in ' + VSCODENAME,
-            tip='Opens VSCode in the current directory'
+            tip='Opens the current directory in VSCode'
         )
         item.connect('activate', self.launch_vscode, [file_])
 

--- a/install.sh
+++ b/install.sh
@@ -47,7 +47,7 @@ rm -f ~/.local/share/nautilus-python/extensions/code-nautilus.py
 
 # Download and install the extension
 echo "Downloading newest version..."
-wget --show-progress -q -O ~/.local/share/nautilus-python/extensions/code-nautilus.py https://raw.githubusercontent.com/cra0zy/code-nautilus/master/code-nautilus.py
+wget --show-progress -q -O ~/.local/share/nautilus-python/extensions/code-nautilus.py https://raw.githubusercontent.com/harry-cpp/code-nautilus/master/code-nautilus.py
 
 # Restart nautilus
 echo "Restarting nautilus..."

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,14 @@
 echo "Installing python-nautilus..."
 if type "pacman" > /dev/null 2>&1
 then
-    sudo pacman -S --noconfirm python-nautilus
+    # check if already install, else install
+    pacman -Qi python-nautilus &> /dev/null
+    if [ `echo $?` -eq 1 ]
+    then
+        sudo pacman -S --noconfirm python-nautilus
+    else
+        echo "python-nautilus is already installed"
+    fi
 elif type "apt-get" > /dev/null 2>&1
 then
     package_name="python-nautilus"


### PR DESCRIPTION
So it does not try to install python-nautilus if already installed, similar to the apt-get and dnf check

fixed wget link in install.sh, and some typos here and there