### PR TITLE
Make it compatible with Nautilus 43

### DIFF
--- a/code-nautilus.py
+++ b/code-nautilus.py
@@ -5,9 +5,6 @@
 #
 # This script was written by cra0zy and is released to the public domain
 
-from gi import require_version
-require_version('Gtk', '3.0')
-require_version('Nautilus', '3.0')
 from gi.repository import Nautilus, GObject
 from subprocess import call
 import os
@@ -42,7 +39,8 @@ class VSCodeExtension(GObject.GObject, Nautilus.MenuProvider):
 
         call(VSCODE + ' ' + args + safepaths + '&', shell=True)
 
-    def get_file_items(self, window, files):
+    def get_file_items(self, *args):
+        files = args[-1]
         item = Nautilus.MenuItem(
             name='VSCodeOpen',
             label='Open in ' + VSCODENAME,
@@ -52,7 +50,8 @@ class VSCodeExtension(GObject.GObject, Nautilus.MenuProvider):
 
         return [item]
 
-    def get_background_items(self, window, file_):
+    def get_background_items(self, *args):
+        file_ = args[-1]
         item = Nautilus.MenuItem(
             name='VSCodeOpenBackground',
             label='Open in ' + VSCODENAME,


### PR DESCRIPTION
The `window` argument was removed from the newest v43 API.

So, to add support for v43 while retaining compatibility with previous versions, we make our callback functions variadic and then we access the `files` argument (the last one in both old and new APIs) by using `args[-1]` instead.

Fixes #26