### PR TITLE
fix: use `/usr/bin/env bash` instead of hardcoded bash path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Install python-nautilus
 echo "Installing python-nautilus..."


### PR DESCRIPTION
This makes your extension work on distros like NixOS, which have different locations for where bash is installed.