### PR TITLE
Installation instructions extended

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ This repo provides a visual studio code extension for Nautilus.
 wget -qO- https://raw.githubusercontent.com/harry-cpp/code-nautilus/master/install.sh | bash
 ```
 
+If you are using Ubuntu 22.04 LTS, you must also install python3-nautilus
+
+```
+sudo apt install python3-nautilus
+```
+
+and restart Gnome or restart Nautilus
+
+```
+nautilus -q && nautilus &
+```
+
 ## Uninstall Extension
 
 ```

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Install python-nautilus
 echo "Installing python-nautilus..."

--- a/install.sh
+++ b/install.sh
@@ -15,11 +15,11 @@ then
 elif type "apt-get" > /dev/null 2>&1
 then
     # Find Ubuntu python-nautilus package
-    package_name="python-nautilus"
+    package_name="python3-nautilus"
     found_package=$(apt-cache search --names-only $package_name)
     if [ -z "$found_package" ]
     then
-        package_name="python3-nautilus"
+        package_name="python-nautilus"
     fi
 
     # Check if the package needs to be installed and install it


### PR DESCRIPTION
Hello,

I discovered this extension today but it didn't work right away on Ubuntu 22.04. There are more steps needed, which I have described. In some distributions python3-nautilus has to be installed for the extension to work.

I hope this is ok.

With kind regards